### PR TITLE
Fix package name typo

### DIFF
--- a/NewAPI/NewAPI.csproj
+++ b/NewAPI/NewAPI.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="AutoMapper" Version="14.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.1.0-eap1" />
-    <PackageReference Include="Microsoft.AspNetCore.AUthentication.JwtBearer" Version="8.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.13">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- fix package name for JwtBearer in `NewAPI.csproj`

## Testing
- `dotnet build NewAPI.sln --no-restore` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a270b134483248707f329be5bceda